### PR TITLE
Fixed GetNext issues

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -29,5 +29,5 @@ import (
 // might occure during a session.
 type Handler interface {
 	Get(value.OID) (value.OID, pdu.VariableType, interface{}, error)
-	GetNext(value.OID, value.OID) (value.OID, pdu.VariableType, interface{}, error)
+	GetNext(value.OID, bool, value.OID) (value.OID, pdu.VariableType, interface{}, error)
 }

--- a/list_handler.go
+++ b/list_handler.go
@@ -62,14 +62,14 @@ func (l *ListHandler) Get(oid value.OID) (value.OID, pdu.VariableType, interface
 }
 
 // GetNext tries to find the value that follows the provided oid and returns it.
-func (l *ListHandler) GetNext(from value.OID, to value.OID) (value.OID, pdu.VariableType, interface{}, error) {
+func (l *ListHandler) GetNext(from value.OID, includeFrom bool, to value.OID) (value.OID, pdu.VariableType, interface{}, error) {
 	if l.items == nil {
 		return nil, pdu.VariableTypeNoSuchObject, nil, nil
 	}
 
 	fromOID, toOID := from.String(), to.String()
 	for _, oid := range l.oids {
-		if oidWithin(oid, fromOID, toOID) {
+		if oidWithin(oid, fromOID, includeFrom, toOID) {
 			return l.Get(value.MustParseOID(oid))
 		}
 	}
@@ -77,11 +77,11 @@ func (l *ListHandler) GetNext(from value.OID, to value.OID) (value.OID, pdu.Vari
 	return nil, pdu.VariableTypeNoSuchObject, nil, nil
 }
 
-func oidWithin(oid, from, to string) bool {
+func oidWithin(oid string, from string, includeFrom bool, to string) bool {
 	oidBytes, fromBytes, toBytes := []byte(oid), []byte(from), []byte(to)
 
 	fromCompare := bytes.Compare(fromBytes, oidBytes)
 	toCompare := bytes.Compare(toBytes, oidBytes)
 
-	return (fromCompare == -1 || fromCompare == 0) && (toCompare == 1)
+	return (fromCompare == -1 || (fromCompare == 0 && includeFrom)) && (toCompare == 1)
 }

--- a/session.go
+++ b/session.go
@@ -168,7 +168,7 @@ func (s *Session) handle(request *pdu.HeaderPacket) *pdu.HeaderPacket {
 			log.Printf("warning: no handler for session specified")
 		} else {
 			for _, sr := range requestPacket.SearchRanges {
-				oid, t, v, err := s.Handler.GetNext(sr.From.GetIdentifier(), sr.To.GetIdentifier())
+				oid, t, v, err := s.Handler.GetNext(sr.From.GetIdentifier(), (sr.From.Include == 1), sr.To.GetIdentifier())
 				if err != nil {
 					log.Printf("error while handling packet: %s", errgo.Details(err))
 					responsePacket.Error = pdu.ErrorProcessing


### PR DESCRIPTION
Updated session and handlers to make use of OID "include" field in search ranges when processing GetNext requests.

Previously running snmpwalk against the example code provided in the README would fail (never ending loop).