### PR TITLE
Workaround for wrong sorting of l.oids

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ import (
 
 	"gopkg.in/errgo.v1"
 
-	"github.com/posteo/go-agentx"
-	"github.com/posteo/go-agentx/pdu"
-	"github.com/posteo/go-agentx/value"
+	"github.com/martinclaro/go-agentx"
+	"github.com/martinclaro/go-agentx/pdu"
+	"github.com/martinclaro/go-agentx/value"
 )
 
 func main() {

--- a/client.go
+++ b/client.go
@@ -28,8 +28,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/posteo/go-agentx/pdu"
-	"github.com/posteo/go-agentx/value"
+	"github.com/martinclaro/go-agentx/pdu"
+	"github.com/martinclaro/go-agentx/value"
 	"gopkg.in/errgo.v1"
 )
 

--- a/environment_test.go
+++ b/environment_test.go
@@ -26,8 +26,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/posteo/go-agentx"
-	"github.com/posteo/go-agentx/value"
+	"github.com/martinclaro/go-agentx"
+	"github.com/martinclaro/go-agentx/value"
 	"gopkg.in/errgo.v1"
 )
 

--- a/handler.go
+++ b/handler.go
@@ -21,8 +21,8 @@ USA
 package agentx
 
 import (
-	"github.com/posteo/go-agentx/pdu"
-	"github.com/posteo/go-agentx/value"
+	"github.com/martinclaro/go-agentx/pdu"
+	"github.com/martinclaro/go-agentx/value"
 )
 
 // Handler defines an interface for a handler of events that

--- a/list_handler.go
+++ b/list_handler.go
@@ -24,8 +24,8 @@ import (
 	"bytes"
 	"sort"
 
-	"github.com/posteo/go-agentx/pdu"
-	"github.com/posteo/go-agentx/value"
+	"github.com/martinclaro/go-agentx/pdu"
+	"github.com/martinclaro/go-agentx/value"
 )
 
 // ListHandler is a helper that takes a list of oids and implements

--- a/list_handler.go
+++ b/list_handler.go
@@ -42,7 +42,8 @@ func (l *ListHandler) Add(oid string) *ListItem {
 	}
 
 	l.oids = append(l.oids, oid)
-	l.oids.Sort()
+	// The following line will break OID order for x.1.1, x.2.1, x.10.1 OID sequence
+	// l.oids.Sort()
 	item := &ListItem{}
 	l.items[oid] = item
 	return item

--- a/list_handler.go
+++ b/list_handler.go
@@ -21,9 +21,9 @@ USA
 package agentx
 
 import (
-	"bytes"
 	"sort"
 
+	"github.com/martinclaro/go-oidsort"
 	"github.com/martinclaro/go-agentx/pdu"
 	"github.com/martinclaro/go-agentx/value"
 )
@@ -42,8 +42,7 @@ func (l *ListHandler) Add(oid string) *ListItem {
 	}
 
 	l.oids = append(l.oids, oid)
-	// The following line will break OID order for x.1.1, x.2.1, x.10.1 OID sequence
-	// l.oids.Sort()
+	sort.Sort(oidsort.ByOidString(l.oids))
 	item := &ListItem{}
 	l.items[oid] = item
 	return item
@@ -79,10 +78,8 @@ func (l *ListHandler) GetNext(from value.OID, includeFrom bool, to value.OID) (v
 }
 
 func oidWithin(oid string, from string, includeFrom bool, to string) bool {
-	oidBytes, fromBytes, toBytes := []byte(oid), []byte(from), []byte(to)
-
-	fromCompare := bytes.Compare(fromBytes, oidBytes)
-	toCompare := bytes.Compare(toBytes, oidBytes)
+	fromCompare := oidsort.CompareOIDs(from, oid)
+	toCompare := oidsort.CompareOIDs(to, oid)
 
 	return (fromCompare == -1 || (fromCompare == 0 && includeFrom)) && (toCompare == 1)
 }

--- a/list_handler_test.go
+++ b/list_handler_test.go
@@ -23,9 +23,9 @@ package agentx_test
 import (
 	"testing"
 
-	. "github.com/posteo/go-agentx"
-	"github.com/posteo/go-agentx/pdu"
-	. "github.com/posteo/go-agentx/test"
+	. "github.com/martinclaro/go-agentx"
+	"github.com/martinclaro/go-agentx/pdu"
+	. "github.com/martinclaro/go-agentx/test"
 )
 
 var listHandler = &ListHandler{}

--- a/list_item.go
+++ b/list_item.go
@@ -20,7 +20,7 @@ USA
 
 package agentx
 
-import "github.com/posteo/go-agentx/pdu"
+import "github.com/martinclaro/go-agentx/pdu"
 
 // ListItem defines an item of the list handler.
 type ListItem struct {

--- a/pdu/get.go
+++ b/pdu/get.go
@@ -20,7 +20,7 @@ USA
 
 package pdu
 
-import "github.com/posteo/go-agentx/value"
+import "github.com/martinclaro/go-agentx/value"
 
 // Get defines the pdu get packet.
 type Get struct {

--- a/pdu/object_identifier.go
+++ b/pdu/object_identifier.go
@@ -24,7 +24,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/posteo/go-agentx/value"
+	"github.com/martinclaro/go-agentx/value"
 	"gopkg.in/errgo.v1"
 )
 

--- a/pdu/open.go
+++ b/pdu/open.go
@@ -21,7 +21,7 @@ USA
 package pdu
 
 import (
-	"github.com/posteo/go-agentx/marshaler"
+	"github.com/martinclaro/go-agentx/marshaler"
 	"gopkg.in/errgo.v1"
 )
 

--- a/pdu/register.go
+++ b/pdu/register.go
@@ -21,7 +21,7 @@ USA
 package pdu
 
 import (
-	"github.com/posteo/go-agentx/marshaler"
+	"github.com/martinclaro/go-agentx/marshaler"
 	"gopkg.in/errgo.v1"
 )
 

--- a/pdu/unregister.go
+++ b/pdu/unregister.go
@@ -21,7 +21,7 @@ USA
 package pdu
 
 import (
-	"github.com/posteo/go-agentx/marshaler"
+	"github.com/martinclaro/go-agentx/marshaler"
 	"gopkg.in/errgo.v1"
 )
 

--- a/pdu/variable.go
+++ b/pdu/variable.go
@@ -26,7 +26,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/posteo/go-agentx/value"
+	"github.com/martinclaro/go-agentx/value"
 	"gopkg.in/errgo.v1"
 )
 

--- a/pdu/variables.go
+++ b/pdu/variables.go
@@ -21,7 +21,7 @@ USA
 package pdu
 
 import (
-	"github.com/posteo/go-agentx/value"
+	"github.com/martinclaro/go-agentx/value"
 	"gopkg.in/errgo.v1"
 )
 

--- a/request.go
+++ b/request.go
@@ -20,7 +20,7 @@ USA
 
 package agentx
 
-import "github.com/posteo/go-agentx/pdu"
+import "github.com/martinclaro/go-agentx/pdu"
 
 type request struct {
 	headerPacket *pdu.HeaderPacket

--- a/session.go
+++ b/session.go
@@ -25,8 +25,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/posteo/go-agentx/pdu"
-	"github.com/posteo/go-agentx/value"
+	"github.com/martinclaro/go-agentx/pdu"
+	"github.com/martinclaro/go-agentx/value"
 	"gopkg.in/errgo.v1"
 )
 

--- a/session_test.go
+++ b/session_test.go
@@ -23,7 +23,7 @@ package agentx_test
 import (
 	"testing"
 
-	. "github.com/posteo/go-agentx/test"
+	. "github.com/martinclaro/go-agentx/test"
 )
 
 func TestSessionOpen(t *testing.T) {

--- a/value/oid_test.go
+++ b/value/oid_test.go
@@ -23,8 +23,8 @@ package value_test
 import (
 	"testing"
 
-	. "github.com/posteo/go-agentx/test"
-	. "github.com/posteo/go-agentx/value"
+	. "github.com/martinclaro/go-agentx/test"
+	. "github.com/martinclaro/go-agentx/value"
 )
 
 func TestCommonPrefix(t *testing.T) {


### PR DESCRIPTION
Sorting following string OIDs will fail into wrong order:

1.3.6.1.4.1.45995.3.1
1.3.6.1.4.1.45995.3.2
1.3.6.1.4.1.45995.3.3
1.3.6.1.4.1.45995.3.10
1.3.6.1.4.1.45995.3.11

This workaround requires to register OIDs in the right order, but it won't fail for those cases.