### PR TITLE
Add SortOIDs and CompareOIDs functions

### DIFF
--- a/value/oid.go
+++ b/value/oid.go
@@ -6,6 +6,7 @@ package value
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -84,6 +85,13 @@ func CompareOIDs(oid1, oid2 OID) int {
 		}
 	}
 	return 1
+}
+
+// SortOIDs performs sorting of the OID list.
+func SortOIDs(oids []OID) {
+	sort.Slice(oids, func(i, j int) bool {
+		return CompareOIDs(oids[i], oids[j]) == -1
+	})
 }
 
 func (o OID) String() string {

--- a/value/oid.go
+++ b/value/oid.go
@@ -61,6 +61,31 @@ func (o OID) CommonPrefix(other OID) OID {
 	return o[:matchCount]
 }
 
+// CompareOIDs returns an integer comparing two OIDs lexicographically.
+// The result will be 0 if oid1 == oid2, -1 if oid1 < oid2, +1 if oid1 > oid2.
+func CompareOIDs(oid1, oid2 OID) int {
+	if oid2 != nil {
+		oid1Length := len(oid1)
+		oid2Length := len(oid2)
+		for i := 0; i < oid1Length && i < oid2Length; i++ {
+			if oid1[i] < oid2[i] {
+				return -1
+			}
+			if oid1[i] > oid2[i] {
+				return 1
+			}
+		}
+		if oid1Length == oid2Length {
+			return 0
+		} else if oid1Length < oid2Length {
+			return -1
+		} else {
+			return 1
+		}
+	}
+	return 1
+}
+
 func (o OID) String() string {
 	var parts []string
 

--- a/value/oid_test.go
+++ b/value/oid_test.go
@@ -52,3 +52,18 @@ func TestCompareOIDs_NilValue(t *testing.T) {
 	expected := 1
 	AssertEquals(t, expected, CompareOIDs(oid1, oid2))
 }
+
+func TestSortOIDs(t *testing.T) {
+	var oidList []OID
+	oid1 := OID{1, 3, 6, 1}
+	oid2 := OID{1, 3, 6, 5, 7}
+	oid3 := OID{1, 3, 6, 1, 12}
+	oid4 := OID{1, 3, 6, 5}
+
+	oidList = append(oidList, oid1, oid2, oid3, oid4)
+	SortOIDs(oidList)
+
+	var expect []OID
+	expect = append(expect, oid1, oid3, oid4, oid2)
+	AssertEquals(t, expect, oidList)
+}

--- a/value/oid_test.go
+++ b/value/oid_test.go
@@ -16,3 +16,39 @@ func TestCommonPrefix(t *testing.T) {
 	result := oid.CommonPrefix(MustParseOID("1.3.6.1.4"))
 	AssertEquals(t, MustParseOID("1.3.6.1"), result)
 }
+
+func TestCompareOIDs_Less(t *testing.T) {
+	oid1 := OID{1, 3, 6, 1, 2}
+	oid2 := OID{1, 3, 6, 1, 4}
+
+	// oid1 < oid2
+	expected := -1
+	AssertEquals(t, expected, CompareOIDs(oid1, oid2))
+}
+
+func TestCompareOIDs_Greater(t *testing.T) {
+	oid1 := OID{1, 3, 6, 1, 2}
+	oid2 := OID{1, 3, 6, 1, 4}
+
+	// oid2 > oid1
+	expected := 1
+	AssertEquals(t, expected, CompareOIDs(oid2, oid1))
+}
+
+func TestCompareOIDs_Equals(t *testing.T) {
+	oid1 := OID{1, 3, 6, 1, 4}
+	oid2 := OID{1, 3, 6, 1, 4}
+
+	// oid1 == oid2
+	expected := 0
+	AssertEquals(t, expected, CompareOIDs(oid1, oid2))
+}
+
+func TestCompareOIDs_NilValue(t *testing.T) {
+	oid1 := OID{1, 3, 6, 1, 4}
+	var oid2 OID
+
+	// oid2 is nil, thus oid1 is greater
+	expected := 1
+	AssertEquals(t, expected, CompareOIDs(oid1, oid2))
+}


### PR DESCRIPTION
Changes in this PR extends `go-agentx/value` package adding new functions:

- **CompareOIDs** compares two OIDs lexicographically;
- **SortOIDs** sorts OID list.

Please, review.