### PR TITLE
Order OIDs numerically, not lexigographically

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ import (
 func main() {
     client, err := agentx.Dial("tcp", "localhost:705")
     if err != nil {
-        log.Fatalf(err)
+        log.Fatal(err)
     }
     client.Timeout = 1 * time.Minute
     client.ReconnectInterval = 1 * time.Second
 
     session, err := client.Session()
     if err != nil {
-        log.Fatalf(err)
+        log.Fatal(err)
     }
 
     listHandler := &agentx.ListHandler{}
@@ -87,7 +87,7 @@ func main() {
     session.Handler = listHandler
 
     if err := session.Register(127, value.MustParseOID("1.3.6.1.4.1.45995.3")); err != nil {
-        log.Fatalf(err)
+        log.Fatal(err)
     }
 
     for {


### PR DESCRIPTION
Bugfix, when having more than 10 OIDs in a tree, this library inserts and orders them lexicographic, including the the example in README.md (which contains a small bug with logging, using `Fatal()` rather than `Fatalf()`) --

Without this fix, the ordering is botched:
```
pim@summer:~/src/vpp-snmp-agent$ snmpwalk -v2c -c public localhost 1.3.6.1.4.1.45995
iso.3.6.1.4.1.45995.3.1 = INTEGER: -123
iso.3.6.1.4.1.45995.3.10 = Counter64: 12345678901234567890
iso.3.6.1.4.1.45995.3.2 = STRING: "echo test"
Error: OID not increasing: iso.3.6.1.4.1.45995.3.10
 >= iso.3.6.1.4.1.45995.3.2
```

With this fix applied, the ordering is changed to numeric:

```
pim@summer:~/src/vpp-snmp-agent$ snmpwalk -v2c -c public localhost 1.3.6.1.4.1.45995
iso.3.6.1.4.1.45995.3.1 = INTEGER: -123
iso.3.6.1.4.1.45995.3.2 = STRING: "echo test"
iso.3.6.1.4.1.45995.3.3 = INTEGER: 8298
iso.3.6.1.4.1.45995.3.4 = OID: iso.3.6.1.4.1.45995.1.5
iso.3.6.1.4.1.45995.3.5 = IpAddress: 10.10.10.10
iso.3.6.1.4.1.45995.3.6 = Counter32: 123
iso.3.6.1.4.1.45995.3.7 = Gauge32: 123
iso.3.6.1.4.1.45995.3.8 = Timeticks: (12300) 0:02:03.00
iso.3.6.1.4.1.45995.3.9 = OPAQUE: 01 02 03 
iso.3.6.1.4.1.45995.3.10 = Counter64: 12345678901234567890
```

PTAL